### PR TITLE
Only create static test data once.

### DIFF
--- a/features-support/hooks/before.js
+++ b/features-support/hooks/before.js
@@ -4,7 +4,7 @@
 module.exports = function beforeHooks() {
 
   // Remove any old test data.
-  this.Before(function(callback) {
+  this.Before('@cleanSlate', function(callback) {
     var world = this;
     world.deleteTestSpecs()
       .then(function() {

--- a/features/presenting/specifications-are-visible.feature
+++ b/features/presenting/specifications-are-visible.feature
@@ -3,11 +3,13 @@ Feature: Specifications are visible to users
   As an interested party
   I want specifications to be visible in a nice web UI.
 
-  The general idea is that anyone should be able to see the specifications stored in a project without having to understand how version control works. The 'internet' and 'server' tags mean that test requires access to the internet or the server to be running respectively.
+  The general idea is that anyone should be able to see the specifications stored in a project without having to understand how version control works. The 'server' tag means that test requires the server to be running.
+
+  Background:
+    Given a set of specifications containing at least one feature file
 
   @server
   Scenario: A list of features is available.
-    Given a set of specifications containing at least one feature file
     When an interested party attempts to view them
     Then the list of features will be visible.
 
@@ -16,16 +18,3 @@ Feature: Specifications are visible to users
     Given a list of feature files is displayed
     When an interested party wants to view the scenarios within that feature file
     Then the scenarios will be visible.
-
-  @internet @server
-  Scenario: Features can be retrieved from a remote Git repo.
-    Given a URL representing a remote Git repo "https://github.com/oss-specs/specs"
-    When an interested party wants to view the features in that repo
-    Then the list of features will be visible.
-
-    @internet @server
-    Scenario: Requesting features for an existing project displays features.
-      Given a URL representing a remote Git repo "https://github.com/oss-specs/specs"
-      When an interested party wants to view the features in that repo
-      And they request the features for the same repository again
-      Then the list of features will be visible.

--- a/features/retrieving/specifications-can-be-retrieved.feature
+++ b/features/retrieving/specifications-can-be-retrieved.feature
@@ -1,0 +1,19 @@
+Feature: Specifications can be retrieved from remote Git repositories.
+  In order to make specifications more accessible
+  As someone interested in the specification for a project stored on a remote Git server
+  I want those specifications to be visible in a nice web UI.
+
+  The general idea is that anyone should be able to see the specifications stored in a project without having to understand how version control works. The '@internet' and '@server' tags mean that tests requires access to the internet or the server to be running respectively. The '@cleanSlate' tag means these tests expect there to be no existing features stored.
+
+  @internet @server @cleanSlate
+  Scenario: Features can be retrieved from a remote Git repo.
+    Given a URL representing a remote Git repo "https://github.com/oss-specs/specs"
+    When an interested party wants to view the features in that repo
+    Then the list of features will be visible.
+
+  @internet @server @cleanSlate
+  Scenario: Requesting features for an existing project displays features.
+    Given a URL representing a remote Git repo "https://github.com/oss-specs/specs"
+    When an interested party wants to view the features in that repo
+    And they request the features for the same repository again
+    Then the list of features will be visible.


### PR DESCRIPTION
Okay, that took a while to fix. Here are the changes I wanted to make:

Only create static test data once - taken care of with a module scope variable set when the data is written.

Explicitly tag tests which expect no existing features, these are effectively end-to-end tests and for now they couldn't be run in parallel.

The only surefire way I can think of handling disk based data between parallel tests is to store it in directories named after a hash of the scenario name but I don't think we need that yet.