### PR TITLE
Feature/tweaking parser api

### DIFF
--- a/features-support/step_definitions/parsing.js
+++ b/features-support/step_definitions/parsing.js
@@ -20,8 +20,9 @@ module.exports = function() {
 
   this.When(/^I parse this specification\.?$/, function () {
     var parser = new GherkinParser();
-    var visitor = parser.parse(featureText);
-    features = visitor.getFeatures();
+    features = parser
+      .parse(featureText)
+      .getFeatures();
   });
 
   this.Then(/^I get a feature with title "([^"]*)"\.?$/, function (featureTitle) {

--- a/lib/parser/gherkin.js
+++ b/lib/parser/gherkin.js
@@ -5,19 +5,21 @@ var Visitor = require('./visitor');
 
 var Lexer = new Gherkin.Lexer("en");
 
+
 module.exports = function GherkinParser() {
-    var visitor = new Visitor();
-    var lexer = new Lexer(visitor);
-    var lexed = false;
+  var visitor = new Visitor();
+  var lexer = new Lexer(visitor);
 
-    this.parse = function(text) {
+  return {
+    lexed: false,
+    parse: function(text) {
       lexer.scan(text);
-      lexed = true;
+      this.lexed = true;
       return this;
-    };
-
-    this.getFeatures = function() {
-      if (!lexed) throw new Error('Can not get features before a feature string has been parsed.');
+    },
+    getFeatures: function() {
+      if (!this.lexed) throw new Error('Can not get features before a feature string has been parsed.');
       return visitor.getFeatures();
-    };
+    }
+  };
 };

--- a/lib/parser/gherkin.js
+++ b/lib/parser/gherkin.js
@@ -3,14 +3,21 @@
 var Gherkin = require('gherkin');
 var Visitor = require('./visitor');
 
+var Lexer = new Gherkin.Lexer("en");
+
 module.exports = function GherkinParser() {
-    return {
-        parse: function(text) {
-            var visitor = new Visitor();
-            var Lexer = new Gherkin.Lexer("en");
-            var lexer = new Lexer(visitor);
-            lexer.scan(text);
-            return visitor;
-        }
+    var visitor = new Visitor();
+    var lexer = new Lexer(visitor);
+    var lexed = false;
+
+    this.parse = function(text) {
+      lexer.scan(text);
+      lexed = true;
+      return this;
+    };
+
+    this.getFeatures = function() {
+      if (!lexed) throw new Error('Can not get features before a feature string has been parsed.');
+      return visitor.getFeatures();
     };
 };

--- a/lib/parser/gherkin.js
+++ b/lib/parser/gherkin.js
@@ -15,6 +15,8 @@ module.exports = function GherkinParser() {
     parse: function(text) {
       lexer.scan(text);
       this.lexed = true;
+
+      // Allow chaining.
       return this;
     },
     getFeatures: function() {


### PR DESCRIPTION
Tweak the parser API to allow chaining, remove the necessity to expose the visitor object to the end user and allow more API endpoints to be added in the future.