### PR TITLE
Output cucumber server test results to file.

### DIFF
--- a/gulp/tasks/testing.js
+++ b/gulp/tasks/testing.js
@@ -83,7 +83,7 @@ gulp.task('test:cucumber:fileoutput', 'Run Cucumber, only output JSON to file.',
       }, commandArgs);
     }
 
-    var stream = spawn('gulp', commandArgs);
+    var stream = spawn('./node_modules/.bin/gulp', commandArgs);
 
     stream.stdout.setEncoding(baseEncoding);
     stream.stderr.setEncoding(baseEncoding);

--- a/gulp/tasks/testing.js
+++ b/gulp/tasks/testing.js
@@ -97,11 +97,22 @@ gulp.task('test:cucumber:fileoutput', 'Run Cucumber, only output JSON to file.',
   options: {'tags': 'Supports same optional tags arguments as \'test:cucumber\' task.'}
 });
 
-// The default Cucumber test run requires server to be running.
+// The default Cucumber test run requires the server to be running.
 gulp.task('test:features', 'Everything necessesary to test the features.', function(done) {
   runSequence('set-envs:test',
               'server:start',
               'test:cucumber',
+              'server:stop',
+              done);
+}, {
+  options: {'tags': 'Supports same optional tags arguments as \'test:cucumber\' task.'}
+});
+
+// The default Cucumber test run requires server to be running.
+gulp.task('test:features:fileoutput', 'Everything necessesary to test the features and send the output to file.', function(done) {
+  runSequence('set-envs:test',
+              'server:start',
+              'test:cucumber:fileoutput',
               'server:stop',
               done);
 }, {

--- a/package.json
+++ b/package.json
@@ -74,5 +74,18 @@
     "require-dir": "^0.3.0",
     "run-sequence": "^1.1.2",
     "should": "^7.0.1"
-  }
+  },
+  "bundleDependencies": [
+    "body-parser",
+    "cookie-parser",
+    "debug",
+    "express",
+    "gherkin",
+    "hbs",
+    "morgan",
+    "newrelic",
+    "nodegit",
+    "q-io",
+    "serve-favicon"
+  ]
 }


### PR DESCRIPTION
Create a gulp task for executing the cucumber tests with the server running and outputting the results to file.