### PR TITLE
Fix the bin name for global npm install and bump the version.

### DIFF
--- a/gulp/tasks/server.js
+++ b/gulp/tasks/server.js
@@ -9,7 +9,7 @@ var gulp = require('gulp-help')(require('gulp'));
 var server = require('gulp-develop-server');
 
 var packagejson = require('../../package.json');
-var binaryPath = packagejson.bin['module-name'];
+var binaryPath = packagejson.bin['oss-specs'];
 
 gulp.task('server:start', 'Start serving the app.', ['set-envs:test'], function(done) {
   server.listen({

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "body-parser": "~1.13.1",
     "cookie-parser": "~1.3.5",
     "express": "~4.13.0",
-    "poc-node-module": "git+https:git.baplc.com:javascript_testing/poc-node-module.git#v0.0.3",
     "file-stream-rotator": "0.0.6",
     "gherkin": "^2.12.1",
     "github-markdown-css": "^2.0.9",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "oss-specs",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "bin": {
-    "module-name": "./bin/www"
+    "oss-specs": "./bin/www"
   },
   "scripts": {
     "prestart": "npm stop",
@@ -61,7 +61,6 @@
     "serve-favicon": "~2.3.0"
   },
   "devDependencies": {
-   
     "codeclimate-test-reporter": "^0.1.0",
     "cucumber": "^0.5.2",
     "cucumber-junit": "^1.3.0",


### PR DESCRIPTION
This fixes the bin name so that after `npm install -g oss-specs` the user should be able to start the server with `oss-specs`.