### PR TITLE
Fixing version number

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oss-specs",
-  "version": "0.14.00",
+  "version": "0.14.0",
   "engines": {
     "node": "4.2.1"
   },


### PR DESCRIPTION
@jimCresswell I have removed extra "0" from the version number which was causing npm version command to fail