### PR TITLE
Stop capturing stderr for the test resutls, so we can dump stuff in s…

### DIFF
--- a/gulp/tasks/testing.js
+++ b/gulp/tasks/testing.js
@@ -86,8 +86,6 @@ gulp.task('test:cucumber:fileoutput', 'Run Cucumber, only output JSON to file.',
   var stream = spawn('./node_modules/.bin/gulp', commandArgs);
 
   stream.stdout.setEncoding(baseEncoding);
-  stream.stderr.setEncoding(baseEncoding);
-  stream.stderr.pipe(fileStream);
   stream.stdout.pipe(fileStream);
   stream.on('close', function(e) {
     fileStream.end();


### PR DESCRIPTION
…tderr and not have it mess up the json to xml conversion.