### PR TITLE
Persist client side state using localStorage

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,6 +6,7 @@
   "Everything else": "See package.json",
   "dependencies": {
     "jquery": "2.1.4",
-    "select2": "4.0.0"
+    "select2": "4.0.0",
+    "lscache": "1.0.5"
   }
 }

--- a/public/javascript/project.js
+++ b/public/javascript/project.js
@@ -150,16 +150,12 @@
     var els = window.document.getElementsByClassName('directory-path');
     [].forEach.call(els, function(el) {
       el.addEventListener('click', function() {
+
         // Expand or collapse the file list.
-        if (this.classList.contains('can-expand')) {
-          this.classList.remove('can-expand');
-          lscache.set(this.id, {expanded:true}, lscacheTimeoutMins);
-          this.nextElementSibling.classList.remove('collapse');
-        } else {
-          this.classList.add('can-expand');
-          lscache.remove(this.id);
-          this.nextElementSibling.classList.add('collapse');
-        }
+        var doExpand = this.classList.contains('can-expand');
+        setExpandClass(doExpand, this, 'can-expand');
+        setExpandClass(doExpand, this.nextElementSibling, 'collapse');
+        cache(doExpand, this.id);
       });
     });
   });

--- a/public/javascript/project.js
+++ b/public/javascript/project.js
@@ -1,8 +1,10 @@
 /* eslint-env browser */
-/* global $ */
+/* global $, lscache */
 
 (function() {
   'use strict';
+
+  var lscacheTimeoutMins = 5;
 
   function getQueryParams(urlString) {
     var search;
@@ -104,6 +106,7 @@
     expandCollapseRepoControlsEl.addEventListener('click', expandCollapseRepoControls);
   });
 
+
   // Expand/collapse file lists button logic.
   $(function() {
     var directoryEls = window.document.getElementsByClassName('directory-path');
@@ -116,8 +119,10 @@
       [].forEach.call(els, function(el) {
         if (doExpand) {
           el.classList.remove('can-expand');
+          lscache.set(el.id, {expanded: true}, lscacheTimeoutMins);
         } else {
           el.classList.add('can-expand');
+          lscache.remove(el.id);
         }
       });
 
@@ -135,22 +140,45 @@
       doExpand = !doExpand;
     }
 
-    var expandCollapseAlEl = window.document.getElementById('expand-collapse-file-lists');
-    expandCollapseAlEl.addEventListener('click', expandCollapseAll);
+    var expandCollapseAllEl = window.document.getElementById('expand-collapse-file-lists');
+    expandCollapseAllEl.addEventListener('click', expandCollapseAll);
   });
 
-  // Expand/collapse individual directories.
+  // Expand/collapse individual directories based on interactions.
   $(function() {
     var els = window.document.getElementsByClassName('directory-path');
     [].forEach.call(els, function(el) {
       el.addEventListener('click', function() {
-        this.classList.toggle('can-expand');
-
         // Expand or collapse the file list.
-        this.nextElementSibling.classList.toggle('collapse');
+        if (this.classList.contains('can-expand')) {
+          this.classList.remove('can-expand');
+          lscache.set(this.id, {expanded:true}, lscacheTimeoutMins);
+          this.nextElementSibling.classList.remove('collapse');
+        } else {
+          this.classList.add('can-expand');
+          lscache.remove(this.id);
+          this.nextElementSibling.classList.add('collapse');
+        }
       });
     });
   });
+
+  // Expand/collapse individual directories based local state
+  $(function() {
+    var els = window.document.getElementsByClassName('directory-path');
+    [].forEach.call(els, function(el) {
+      var id = el.id;
+      var state = lscache.get(id);
+      if (state && state.expanded) {
+        el.classList.remove('can-expand');
+        el.nextElementSibling.classList.remove('collapse');
+      } else {
+        el.classList.add('can-expand');
+        el.nextElementSibling.classList.add('collapse');
+      }
+    });
+  });
+
 
   // Tag selecting element logic.
   $(function() {

--- a/public/javascript/project.js
+++ b/public/javascript/project.js
@@ -53,26 +53,23 @@
     }, '?');
   }
 
-  function cache(id) {
-    lscache.set(id, {expanded: true}, lscacheTimeoutMins);
+  function cache(doExpand, id) {
+    lscache.set(id, {expanded: doExpand}, lscacheTimeoutMins);
   }
 
-  function uncache(id) {
-    lscache.remove(id);
+  function setExpandClass(doExpand, el, className) {
+    if (doExpand) {
+      el.classList.remove(className);
+    } else {
+      el.classList.add(className);
+    }
   }
 
-  function expandOrCollapse(doExpand, els, className, cache, uncache) {
+  function expandOrCollapse(doExpand, els, className, doCache) {
     [].forEach.call(els, function(el) {
-      if (doExpand) {
-        el.classList.remove(className);
-        if (typeof cache === 'function') {
-          cache(el.id);
-        }
-      } else {
-        el.classList.add(className);
-        if (typeof cache === 'function') {
-          uncache(el.id);
-        }
+      setExpandClass(doExpand, el, className);
+      if (doCache) {
+        cache(doExpand, el.id);
       }
     });
   }
@@ -134,20 +131,18 @@
   // Expand/collapse file lists button logic.
   $(function() {
     var directoryEls = window.document.getElementsByClassName('directory-path');
-    var doExpand = [].every.call(directoryEls, function(el) { return el.classList.contains('can-expand'); });
 
     function expandCollapseAll() {
       var els;
+      var doExpand = [].every.call(directoryEls, function(el) { return el.classList.contains('can-expand'); });
       var parent = document.getElementsByClassName('spec-links')[0];
+      var doCache = true;
 
       els = parent.getElementsByClassName('directory-path');
-      expandOrCollapse(doExpand, els, 'can-expand', cache, uncache);
+      expandOrCollapse(doExpand, els, 'can-expand', doCache);
 
       els = parent.getElementsByClassName('file-list');
       expandOrCollapse(doExpand, els, 'collapse');
-
-      // Toggle expansion on alternative executions.
-      doExpand = !doExpand;
     }
 
     var expandCollapseAllEl = window.document.getElementById('expand-collapse-file-lists');

--- a/public/javascript/project.js
+++ b/public/javascript/project.js
@@ -113,11 +113,7 @@
       repoControlsEl.classList.toggle('collapse');
       openBurgerMenu = !repoControlsEl.classList.contains('collapse');
 
-      if (openBurgerMenu) {
-        burgerMenuEl.classList.add('open');
-      } else {
-        burgerMenuEl.classList.remove('open');
-      }
+      setExpandClass(!openBurgerMenu, burgerMenuEl, 'open');
 
       // Persist the burger menu state in a cookie for five minutes.
       window.document.cookie = 'specsOpenBurgerMenu=' + openBurgerMenu + ';max-age=' + 5 * 60;

--- a/public/javascript/project.js
+++ b/public/javascript/project.js
@@ -4,7 +4,7 @@
 (function() {
   'use strict';
 
-  var lscacheTimeoutMins = 5;
+  var lscacheTimeoutMins = 30;
 
   function getQueryParams(urlString) {
     var search;

--- a/public/javascript/project.js
+++ b/public/javascript/project.js
@@ -166,13 +166,9 @@
     [].forEach.call(els, function(el) {
       var id = el.id;
       var state = lscache.get(id);
-      if (state && state.expanded) {
-        el.classList.remove('can-expand');
-        el.nextElementSibling.classList.remove('collapse');
-      } else {
-        el.classList.add('can-expand');
-        el.nextElementSibling.classList.add('collapse');
-      }
+      var doExpand = state && state.expanded;
+      setExpandClass(doExpand, el, 'can-expand');
+      setExpandClass(doExpand, el.nextElementSibling, 'collapse');
     });
   });
 

--- a/public/javascript/project.js
+++ b/public/javascript/project.js
@@ -53,6 +53,30 @@
     }, '?');
   }
 
+  function cache(id) {
+    lscache.set(id, {expanded: true}, lscacheTimeoutMins);
+  }
+
+  function uncache(id) {
+    lscache.remove(id);
+  }
+
+  function expandOrCollapse(doExpand, els, className, cache, uncache) {
+    [].forEach.call(els, function(el) {
+      if (doExpand) {
+        el.classList.remove(className);
+        if (typeof cache === 'function') {
+          cache(el.id);
+        }
+      } else {
+        el.classList.add(className);
+        if (typeof cache === 'function') {
+          uncache(el.id);
+        }
+      }
+    });
+  }
+
   // Branch changing select element logic.
   $(function() {
     var selectEl = $('#change-branch-control');
@@ -115,26 +139,12 @@
     function expandCollapseAll() {
       var els;
       var parent = document.getElementsByClassName('spec-links')[0];
-      els = parent.getElementsByClassName('directory-path');
-      [].forEach.call(els, function(el) {
-        if (doExpand) {
-          el.classList.remove('can-expand');
-          lscache.set(el.id, {expanded: true}, lscacheTimeoutMins);
-        } else {
-          el.classList.add('can-expand');
-          lscache.remove(el.id);
-        }
-      });
 
+      els = parent.getElementsByClassName('directory-path');
+      expandOrCollapse(doExpand, els, 'can-expand', cache, uncache);
 
       els = parent.getElementsByClassName('file-list');
-      [].forEach.call(els, function(el) {
-        if (doExpand) {
-          el.classList.remove('collapse');
-        } else {
-          el.classList.add('collapse');
-        }
-      });
+      expandOrCollapse(doExpand, els, 'collapse');
 
       // Toggle expansion on alternative executions.
       doExpand = !doExpand;

--- a/views/project.hbs
+++ b/views/project.hbs
@@ -4,6 +4,7 @@
 <link href="/bower/select2/dist/css/select2.min.css" rel="stylesheet" />
 <script src="/bower/jquery/dist/jquery.min.js"></script>
 <script src="/bower/select2/dist/js/select2.min.js"></script>
+<script src="/bower/lscache/lscache.min.js"></script>
 <script src="/public/javascript/project.js"></script>
 <script src="/public/javascript/loader.js"></script>
 {{> layout_start_body}}
@@ -75,7 +76,7 @@
         {{/if}}
         {{#each project.filesByDir as |files directoryPath|}}
           <section class="directory">
-            <h2 class="directory-path interactive {{#if ../projectView.[start collapsed]}}can-expand{{/if}}" title="{{directoryPath}}">{{#directory_path directoryPath pathsToHideRegex=../projectView.regex.pathsToHide}}{{this}}{{/directory_path}}</h2>
+            <h2 class="directory-path interactive {{#if ../projectView.[start collapsed]}}can-expand{{/if}}" title="{{directoryPath}}" id="{{# uri_encode directoryPath}}{{this}}{{/uri_encode}}">{{#directory_path directoryPath pathsToHideRegex=../projectView.regex.pathsToHide}}{{this}}{{/directory_path}}</h2>
             <ul class="file-list collapsible {{#if ../projectView.[start collapsed]}}collapse{{/if}}">
               {{#each files}}
                 {{#if this.isFeatureFile}}


### PR DESCRIPTION
We've had feedback that users would like the app state to persist between page reloads. This has been achieved with client side storage of state using a wrapper around the localStorage API which provides the ability to set TTLs on the cached data.

This PR persists state on the Project page around which of the file lists are expanded.
