### PR TITLE
Displaying specifications in an iFrame using dedicated url instead of…

### DIFF
--- a/app.js
+++ b/app.js
@@ -61,6 +61,7 @@ hbs.registerHelper('directory_path', handlebarHelpers.directoryPath);
 hbs.registerHelper('uri_encode', handlebarHelpers.uriEncodeString);
 hbs.registerHelper('test_results', handlebarHelpers.checkResultsFromList);
 hbs.registerHelper('if_eq', handlebarHelpers.ifEquals);
+hbs.registerHelper('debug', handlebarHelpers.debug);
 
 /**
  * LOGGING.

--- a/lib/specifications/files/get-content-url.js
+++ b/lib/specifications/files/get-content-url.js
@@ -1,0 +1,10 @@
+/**
+ * Generate a link for editing a file in a Git repo.
+ */
+'use strict';
+
+var handlebars = require('hbs').handlebars;
+
+module.exports = function getContentUrl(fileUrl) {
+  return fileUrl.replace(/(\/project\/.*?\/file)/, "$1Content");
+};

--- a/lib/specifications/files/get-content-url.js
+++ b/lib/specifications/files/get-content-url.js
@@ -3,8 +3,6 @@
  */
 'use strict';
 
-var handlebars = require('hbs').handlebars;
-
 module.exports = function getContentUrl(fileUrl) {
-  return fileUrl.replace(/(\/project\/.*?\/file)/, "$1Content");
+  return fileUrl.replace(/(\/project\/.*?\/file)/, '$1Content');
 };

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "markdown": "^0.5.0",
     "morgan": "^1.6.1",
     "newrelic": "^1.22.1",
-    "nodegit": "^0.15.0",
+    "nodegit": "^0.19.0",
     "q": "^1.4.1",
     "q-io": "^1.13.1",
     "request-promise": "^3.0.0",

--- a/routes/feature.js
+++ b/routes/feature.js
@@ -35,7 +35,7 @@ function markTargetedFeature(feature, targetedScenarioName) {
 }
 
 router.get(/([^\/]+)\/fileContent\/([\w\W]+)/, function (req, res, next) {
-var repoName = req.params[0];
+  var repoName = req.params[0];
   var filePath = req.params[1];
   var ref = req.query.ref;
 
@@ -44,13 +44,7 @@ var repoName = req.params[0];
     localPathRoot: appConfig.projectsPath,
     currentBranchName: ref
   };
-
-  // Skip the rendering for query param ?plain=true ?plain=1 etc.
-  var renderPlainFile = req.query.plain === 'true' || !!parseInt(req.query.plain);
-
-  // Optional name of a particular scenario.
-  var targetedScenarioName = req.query.scenario || false;
-
+  
   // An object referring to the file we want to render.
   var file;
 

--- a/views/helpers/index.js
+++ b/views/helpers/index.js
@@ -182,6 +182,9 @@ module.exports = {
   newlinesToParagraphs: getStringConverter(function toParagraphs(safeContent) {
     return '<p>' + safeContent + '</p>';
   }),
+  debug: function(text) {
+    return JSON.stringify(text, null, 4);
+  },
   stepContent: highlightStepParams,
   directoryPath: parseDirectoryPath,
   uriEncodeString: uriEncodeString,

--- a/views/html-file.hbs
+++ b/views/html-file.hbs
@@ -13,7 +13,7 @@
   </header>
 
   <section class="html-body">
-    <iframe src="data:text/html,{{file.content}}" />
+    <iframe src="{{ file.contentUrl }}" />
   </section>
 </main>
 {{> layout_end}}


### PR DESCRIPTION
… base64 - this was not working in some browsers

Closes #241 

@jimCresswell  if you have a minute, this is really a bug fix for displaying HTML specifications but not as a base64 which does not work in many browsers, but rather as a dedicated route