### PR TITLE
Improving the performance of retrieving specifications

### DIFF
--- a/lib/specifications/files/get-edit-url.js
+++ b/lib/specifications/files/get-edit-url.js
@@ -6,14 +6,15 @@
 var handlebars = require('hbs').handlebars;
 
 module.exports = function getEditUrl(projectData, filePath) {
-  var editUrlTemplate;
 
   if (!projectData.config.editUrlFormat) {
     return;
   }
 
-  editUrlTemplate = handlebars.compile(projectData.config.editUrlFormat);
-  return editUrlTemplate({
+  projectData.editUrlTemplate = projectData.editUrlTemplate ||
+      handlebars.compile(projectData.config.editUrlFormat);
+
+  return projectData.editUrlTemplate({
     repoUrl: projectData.repoUrl,
     repoUrlWithoutGitSuffix: projectData.repoUrl.replace(/\.git$/i, ''),
     branchName: projectData.currentShortBranchName,

--- a/public/css/project.css
+++ b/public/css/project.css
@@ -129,8 +129,8 @@ ul.file-list {
 }
 
 .project-branch select {
-  min-width: 30%;
-  max-width: 60%;
+  min-width: 40%;
+  max-width: 80%;
 }
 
 .project-commit {


### PR DESCRIPTION
When there is a lot of files, there is a performance hit in the
addEditLinks function by not caching the template function. This
commit adds caching on the project level which shaves off 30%
of the rendering time.

Also improvement to select branch drop down as with long branch names
it is not wide enough to read full branch name.